### PR TITLE
Fix for compile issues with ESP-IDF

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -90,7 +90,7 @@ static uint64_t minitar_parse_octal(const char* str)
 {
     uint64_t result = 0;
 
-    while (isspace(*str)) str++;
+    while (isspace((unsigned char)*str)) str++;
 
     while (is_valid_octal_digit(*str))
     {

--- a/src/util.c
+++ b/src/util.c
@@ -243,7 +243,7 @@ void minitar_construct_header_from_metadata(struct tar_header* hdr, const struct
     // We intentionally want strncpy to not write a null terminator here if the path field is 100 bytes long.
     strncpy(hdr->name, metadata->path, 100);
 
-    snprintf(hdr->mode, 8, "%.7o", metadata->mode);
+    snprintf(hdr->mode, 8, "%.7lu", metadata->mode);
     snprintf(hdr->uid, 8, "%.7o", metadata->uid);
     snprintf(hdr->gid, 8, "%.7o", metadata->gid);
 
@@ -280,7 +280,7 @@ void minitar_construct_header_from_metadata(struct tar_header* hdr, const struct
     memset(hdr->padding, 0, sizeof(hdr->padding));
 
     uint32_t checksum = minitar_checksum_header(hdr);
-    snprintf(hdr->chksum, 8, "%.7o", checksum);
+    snprintf(hdr->chksum, 8, "%.7lu", checksum);
 }
 
 int minitar_validate_header(const struct tar_header* hdr)


### PR DESCRIPTION
This fixes the issue described in https://github.com/gabscoarnec/minitar/issues/1
I ran the build with ESP-IDF (32bit) and PC with GCC (64bit).

If you use a different compiler than GCC: please check before it merging.